### PR TITLE
Fix /notes prerender crash from malformed quoted-tweet entities

### DIFF
--- a/app/components/Tweet.tsx
+++ b/app/components/Tweet.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react'
-import { Tweet as ReactTweet } from 'react-tweet'
+import { EmbeddedTweet } from 'react-tweet'
+import { getTweet, type Tweet as TweetData } from 'react-tweet/api'
 import 'react-tweet/theme.css'
 
 function TweetFallback({ url }: { url?: string }) {
@@ -25,16 +26,49 @@ function TweetFallback({ url }: { url?: string }) {
 }
 
 /**
- * Server-rendered X/Twitter embed. `react-tweet` fetches tweet data from X's
- * public syndication API during render, so this works with SSR + ISR without
- * needing client-side `widgets.js`.
+ * X's syndication API sometimes returns a (quoted) tweet whose `entities` object
+ * is empty `{}`. react-tweet's `enrichTweet` then runs `for (…of entities.hashtags)`
+ * with no guard and throws `c is not iterable`, which fails the entire `/notes`
+ * prerender. Backfill the four required entity arrays (`media` is already guarded
+ * upstream) so enrichment can never throw.
+ */
+function ensureEntities(t: { entities?: unknown } | null | undefined): void {
+  if (!t) return
+  const obj = t as { entities?: Record<string, unknown> }
+  const e = (obj.entities ??= {})
+  for (const key of ['hashtags', 'user_mentions', 'urls', 'symbols'] as const) {
+    if (!Array.isArray(e[key])) e[key] = []
+  }
+}
+
+function sanitizeTweet(tweet: TweetData): TweetData {
+  ensureEntities(tweet)
+  ensureEntities(tweet.quoted_tweet)
+  return tweet
+}
+
+async function TweetContent({ id, url }: { id: string; url?: string }) {
+  let tweet: TweetData | undefined
+  try {
+    tweet = await getTweet(id, { next: { revalidate: 3600 } } as RequestInit)
+  } catch {
+    return <TweetFallback url={url} />
+  }
+  if (!tweet) return <TweetFallback url={url} />
+  return <EmbeddedTweet tweet={sanitizeTweet(tweet)} />
+}
+
+/**
+ * Server-rendered X/Twitter embed. We fetch tweet data ourselves (instead of
+ * react-tweet's bundled `<Tweet>`) so we can sanitize malformed entities before
+ * react-tweet enriches them — see `sanitizeTweet`. Works with SSR + ISR.
  */
 export default function Tweet({ id, url }: { id: string; url?: string }) {
   return (
     <div className="tweet-embed not-prose my-6 flex justify-center" data-theme="light">
       <Suspense fallback={<TweetFallback url={url} />}>
-        {/* react-tweet's server component resolves tweet data during render */}
-        <ReactTweet id={id} />
+        {/* fetches + sanitizes tweet data during render */}
+        <TweetContent id={id} url={url} />
       </Suspense>
     </div>
   )


### PR DESCRIPTION
X's syndication API sometimes returns a quoted tweet whose `entities` object is empty `{}`. react-tweet's `enrichTweet` iterates `entities.hashtags/user_mentions/urls/symbols` with no guard, throwing `TypeError: c is not iterable` during render. With no error boundary, that one bad embed (tweet 2047371461036556756, quoting 2045667827735306745, in note #14) failed the entire `/notes` static export on Vercel.

Fetch tweet data ourselves via `getTweet`, backfill the four required entity arrays on both the tweet and its quoted tweet, then render `EmbeddedTweet`. A fetch failure falls back to the "View on X" link.