### PR TITLE
Notes images: self-healing proxy for short-lived GitHub asset URLs

### DIFF
--- a/app/api/notes-media/route.ts
+++ b/app/api/notes-media/route.ts
@@ -1,15 +1,30 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { noteImageUrlShouldBeProxied } from 'app/lib/rewrite-note-images'
+import { resolveFreshIssueImageSrc } from 'app/lib/github-issue-body-html'
 
 /**
  * Proxies GitHub-hosted note images so they work for private repos (browser requests
  * cannot send GITHUB_TOKEN; the issue body still contains raw user-images URLs).
+ *
+ * When `issue` is provided and the direct fetch fails (user-attachments URLs on
+ * private repos, or private-user-images URLs whose ~5-minute JWT expired), the
+ * proxy re-resolves a fresh URL from the issue's rendered HTML via GraphQL.
  */
+
+/** URL forms whose failures can be fixed by re-resolving through GraphQL. */
+function canReResolve(u: URL): boolean {
+  if (u.hostname === 'private-user-images.githubusercontent.com') return true
+  if (u.hostname === 'github.com' && u.pathname.startsWith('/user-attachments/assets/')) return true
+  return false
+}
+
 export async function GET(req: NextRequest) {
   const raw = req.nextUrl.searchParams.get('url')
   if (!raw) {
     return new NextResponse('Missing url', { status: 400 })
   }
+  const issueRaw = req.nextUrl.searchParams.get('issue')
+  const issueNumber = issueRaw != null ? Number(issueRaw) : NaN
 
   let decoded: string
   try {
@@ -47,7 +62,21 @@ export async function GET(req: NextRequest) {
     headers.Authorization = `Bearer ${token}`
   }
 
-  const upstream = await fetch(trimmed, { headers, redirect: 'follow' })
+  let upstream = await fetch(trimmed, { headers, redirect: 'follow' })
+
+  if (!upstream.ok && Number.isFinite(issueNumber) && issueNumber > 0 && canReResolve(u)) {
+    const fresh = await resolveFreshIssueImageSrc(issueNumber, trimmed)
+    if (fresh && fresh !== trimmed && noteImageUrlShouldBeProxied(fresh)) {
+      // Freshly-minted JWT URLs are directly fetchable; no Authorization needed.
+      upstream = await fetch(fresh, {
+        headers: {
+          Accept: 'image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8',
+          'User-Agent': 'eric-dodds-blog/notes-media',
+        },
+        redirect: 'follow',
+      })
+    }
+  }
 
   if (!upstream.ok) {
     return new NextResponse('Image unavailable', {

--- a/app/lib/github-issue-body-html.ts
+++ b/app/lib/github-issue-body-html.ts
@@ -1,6 +1,5 @@
-import { cacheTag } from 'next/cache'
 import { stripTypefullySocialHtmlCommentsForMdx } from 'app/lib/note-social-block'
-import { GITHUB_NOTES_CACHE_TAG, applyNotesCacheLife, getNotesGitHubRepo } from 'app/lib/github-notes'
+import { getNotesGitHubRepo } from 'app/lib/github-notes'
 
 const USER_ATTACHMENTS = 'github.com/user-attachments/assets/'
 
@@ -8,18 +7,15 @@ const USER_ATTACHMENTS = 'github.com/user-attachments/assets/'
  * Issue `body` from the REST API uses `github.com/user-attachments/assets/:id`, which
  * returns 404 for unauthenticated / non-browser requests on private repos.
  * GraphQL `bodyHTML` contains the rendered `<img src="…">` URLs GitHub actually serves
- * (e.g. `private-user-images…` with a short-lived JWT).
+ * (e.g. `private-user-images…` with a short-lived ~5-minute JWT).
  *
- * 'use cache' both persists across requests (fresh-on-refresh in dev, hour-scale +
- * webhook tag invalidation in prod) and dedupes same-key calls within a render, so
- * no react.cache wrapper is needed — wrapping a 'use cache' function in react.cache
- * crashes prerendering ("Invalid value used as weak map key").
+ * Because those JWTs expire in minutes, resolved URLs must never be baked into
+ * cached page HTML — pages proxy the stable user-attachments URL through
+ * /api/notes-media (which calls back into `resolveFreshIssueImageSrc` on demand).
+ * This uncached fetch is for request-time consumers: the media proxy and the
+ * Typefully push (which uploads immediately, while the JWT is fresh).
  */
-export async function getIssueBodyHtml(issueNumber: number): Promise<string | null> {
-  'use cache'
-  cacheTag(GITHUB_NOTES_CACHE_TAG)
-  applyNotesCacheLife()
-
+async function fetchIssueBodyHtmlFresh(issueNumber: number): Promise<string | null> {
   const repo = getNotesGitHubRepo()
   const token = process.env.GITHUB_TOKEN?.trim()
   if (!repo || !token || !Number.isFinite(issueNumber)) return null
@@ -44,6 +40,7 @@ export async function getIssueBodyHtml(issueNumber: number): Promise<string | nu
       query,
       variables: { owner: repo.owner, name: repo.repo, number: issueNumber },
     }),
+    cache: 'no-store',
   })
 
   if (!res.ok) {
@@ -88,6 +85,34 @@ function isResolvedIssueImageSrc(src: string): boolean {
   )
 }
 
+const ASSET_UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
+
+/**
+ * Request-time resolution for the media proxy: fetch the issue's rendered HTML
+ * fresh (new JWT) and return the served `src` matching `originalUrl`'s asset
+ * UUID. Works for both `github.com/user-attachments/assets/<uuid>` originals
+ * and expired `private-user-images…<uuid>.png?jwt=…` URLs, whose filenames
+ * embed the same UUID.
+ */
+export async function resolveFreshIssueImageSrc(
+  issueNumber: number,
+  originalUrl: string
+): Promise<string | null> {
+  const html = await fetchIssueBodyHtmlFresh(issueNumber)
+  if (!html) return null
+
+  const srcs = extractImgSrcsFromIssueBodyHtml(html).filter(isResolvedIssueImageSrc)
+  if (srcs.length === 0) return null
+
+  const uuid = originalUrl.match(ASSET_UUID_RE)?.[0]?.toLowerCase()
+  if (uuid) {
+    const hit = srcs.find((s) => s.toLowerCase().includes(uuid))
+    if (hit) return hit
+  }
+  // No UUID match — only safe to guess when the issue has exactly one image.
+  return srcs.length === 1 ? srcs[0] : null
+}
+
 /**
  * Pair `…/user-attachments/assets/…` markdown URLs with rendered `<img src>` order from `bodyHTML`.
  */
@@ -114,14 +139,20 @@ export function resolveUserAttachmentMarkdown(markdown: string, bodyHtml: string
   return out
 }
 
-/** When markdown still has user-attachments links, swap in resolvable URLs from GraphQL HTML. */
+/**
+ * Swap user-attachments links for URLs that resolve outside a browser session.
+ * For immediate consumers only (Typefully upload right after a webhook) — the
+ * substituted JWT URLs expire in ~5 minutes, so never cache or render this
+ * output into page HTML. Pages keep the stable user-attachments URLs and let
+ * the /api/notes-media proxy resolve them per request instead.
+ */
 export async function resolveNoteBodyWithIssueHtml(
   body: string | null,
   issueNumber: number
 ): Promise<string> {
   let s = body || ''
   if (s.includes(USER_ATTACHMENTS)) {
-    const html = await getIssueBodyHtml(issueNumber)
+    const html = await fetchIssueBodyHtmlFresh(issueNumber)
     if (html) s = resolveUserAttachmentMarkdown(s, html)
   }
   return stripTypefullySocialHtmlCommentsForMdx(s)

--- a/app/lib/github-note-images-mdx.ts
+++ b/app/lib/github-note-images-mdx.ts
@@ -2,7 +2,12 @@ import type { Node } from 'unist'
 import { visit } from 'unist-util-visit'
 import { buildNoteImageProxyUrl } from 'app/lib/rewrite-note-images'
 
-function patchImgPropertiesSrc(properties: Record<string, unknown> | undefined): void {
+export type NoteImagePluginOptions = { issueNumber?: number }
+
+function patchImgPropertiesSrc(
+  properties: Record<string, unknown> | undefined,
+  issueNumber?: number
+): void {
   if (!properties?.src) return
   const raw = properties.src
   const s =
@@ -12,7 +17,7 @@ function patchImgPropertiesSrc(properties: Record<string, unknown> | undefined):
         ? raw.find((x): x is string => typeof x === 'string')
         : undefined
   if (!s) return
-  const proxied = buildNoteImageProxyUrl(s)
+  const proxied = buildNoteImageProxyUrl(s, issueNumber)
   if (proxied) properties.src = proxied
 }
 
@@ -24,24 +29,27 @@ type MdxJsxImgNode = { type?: string; name?: string; attributes?: MdxJsxAttribut
  * parses as JSX elements (mdxJsxFlowElement/mdxJsxTextElement) — NOT as mdast
  * 'html' nodes or hast 'element' nodes, so the other visitors never see them.
  */
-function patchMdxJsxImgSrc(node: MdxJsxImgNode): void {
+function patchMdxJsxImgSrc(node: MdxJsxImgNode, issueNumber?: number): void {
   if (node.name !== 'img' || !Array.isArray(node.attributes)) return
   const attr = node.attributes.find(
     (a) => a.type === 'mdxJsxAttribute' && a.name === 'src'
   )
   if (!attr || typeof attr.value !== 'string') return
-  const proxied = buildNoteImageProxyUrl(attr.value)
+  const proxied = buildNoteImageProxyUrl(attr.value, issueNumber)
   if (proxied) attr.value = proxied
 }
 
 /**
  * Rewrite mdast image + inline HTML <img> before MDX compiles to JSX.
+ * Pass `{ issueNumber }` so the proxy can re-resolve expired/auth-only GitHub
+ * URLs at request time.
  */
-export function remarkGithubNoteImages() {
+export function remarkGithubNoteImages(options?: NoteImagePluginOptions) {
+  const issueNumber = options?.issueNumber
   return function remarkGithubNoteImagesTree(tree: Node) {
     visit(tree, 'image', (node: { url?: string }) => {
       if (typeof node.url !== 'string') return
-      const proxied = buildNoteImageProxyUrl(node.url)
+      const proxied = buildNoteImageProxyUrl(node.url, issueNumber)
       if (proxied) node.url = proxied
     })
     visit(tree, 'html', (node: { value?: string }) => {
@@ -49,24 +57,25 @@ export function remarkGithubNoteImages() {
       node.value = node.value.replace(
         /(<img\b[^>]*\bsrc=)(["'])([^"']+)(\2)/gi,
         (full, pre: string, q: string, url: string) => {
-          const proxied = buildNoteImageProxyUrl(url)
+          const proxied = buildNoteImageProxyUrl(url, issueNumber)
           return proxied ? `${pre}${q}${proxied}${q}` : full
         }
       )
     })
-    visit(tree, 'mdxJsxFlowElement', (node: MdxJsxImgNode) => patchMdxJsxImgSrc(node))
-    visit(tree, 'mdxJsxTextElement', (node: MdxJsxImgNode) => patchMdxJsxImgSrc(node))
+    visit(tree, 'mdxJsxFlowElement', (node: MdxJsxImgNode) => patchMdxJsxImgSrc(node, issueNumber))
+    visit(tree, 'mdxJsxTextElement', (node: MdxJsxImgNode) => patchMdxJsxImgSrc(node, issueNumber))
   }
 }
 
 /**
  * Catch any `img` in hast (covers MDX/GMF output that skipped remark passes).
  */
-export function rehypeGithubNoteImages() {
+export function rehypeGithubNoteImages(options?: NoteImagePluginOptions) {
+  const issueNumber = options?.issueNumber
   return function rehypeGithubNoteImagesTree(tree: Node) {
     visit(tree, 'element', (node: Record<string, unknown>) => {
       if (node.tagName !== 'img') return
-      patchImgPropertiesSrc(node.properties as Record<string, unknown> | undefined)
+      patchImgPropertiesSrc(node.properties as Record<string, unknown> | undefined, issueNumber)
     })
   }
 }

--- a/app/lib/rewrite-note-images.ts
+++ b/app/lib/rewrite-note-images.ts
@@ -34,9 +34,17 @@ export function noteImageUrlShouldBeProxied(url: string): boolean {
   }
 }
 
-/** Same-origin path + query the browser and MDX use for a GitHub image `src`. */
-export function buildNoteImageProxyUrl(original: string): string | null {
+/**
+ * Same-origin path + query the browser and MDX use for a GitHub image `src`.
+ * Pass `issueNumber` so the proxy can re-resolve a fresh URL via GraphQL when
+ * the direct fetch fails (private-repo user-attachments, expired JWT links).
+ */
+export function buildNoteImageProxyUrl(original: string, issueNumber?: number): string | null {
   const t = original.trim()
   if (!noteImageUrlShouldBeProxied(t)) return null
-  return `${PROXY_PATH}?url=${encodeURIComponent(t)}`
+  const issue =
+    typeof issueNumber === 'number' && Number.isFinite(issueNumber)
+      ? `&issue=${issueNumber}`
+      : ''
+  return `${PROXY_PATH}?url=${encodeURIComponent(t)}${issue}`
 }

--- a/app/notes/[number]/page.tsx
+++ b/app/notes/[number]/page.tsx
@@ -10,7 +10,7 @@ import {
   getNoteByNumber,
   getNotes,
 } from 'app/lib/github-notes'
-import { resolveNoteBodyWithIssueHtml } from 'app/lib/github-issue-body-html'
+import { stripTypefullySocialHtmlCommentsForMdx } from 'app/lib/note-social-block'
 import { noteMdxComponents } from 'app/lib/note-mdx-components'
 import { remarkGithubNoteImages, rehypeGithubNoteImages } from 'app/lib/github-note-images-mdx'
 import { rehypeEmbedUnwrap } from 'app/lib/rehype-embed-unwrap'
@@ -85,7 +85,10 @@ export default async function NotePage({
   const note = await getNoteByNumber(num)
   if (!note) notFound()
 
-  const mdxSource = await resolveNoteBodyWithIssueHtml(note.body, note.number)
+  // GitHub image URLs stay in their stable user-attachments form; the MDX
+  // plugins proxy them through /api/notes-media?issue=N, which resolves
+  // short-lived private-repo URLs at request time.
+  const mdxSource = stripTypefullySocialHtmlCommentsForMdx(note.body || '')
 
   return (
     <section>
@@ -118,8 +121,8 @@ export default async function NotePage({
           components={noteMdxComponents}
           options={{
             mdxOptions: {
-              remarkPlugins: [remarkGfm, remarkGithubNoteImages],
-              rehypePlugins: [rehypeGithubNoteImages, rehypeSlug, rehypeEmbedUnwrap],
+              remarkPlugins: [remarkGfm, [remarkGithubNoteImages, { issueNumber: num }]],
+              rehypePlugins: [[rehypeGithubNoteImages, { issueNumber: num }], rehypeSlug, rehypeEmbedUnwrap],
             },
           }}
         />

--- a/app/notes/page.tsx
+++ b/app/notes/page.tsx
@@ -4,7 +4,7 @@ import { MDXRemote } from 'next-mdx-remote/rsc'
 import remarkGfm from 'remark-gfm'
 import rehypeSlug from 'rehype-slug'
 import { getNotes } from 'app/lib/github-notes'
-import { resolveNoteBodyWithIssueHtml } from 'app/lib/github-issue-body-html'
+import { stripTypefullySocialHtmlCommentsForMdx } from 'app/lib/note-social-block'
 import { noteMdxComponents } from 'app/lib/note-mdx-components'
 import { remarkGithubNoteImages, rehypeGithubNoteImages } from 'app/lib/github-note-images-mdx'
 import { rehypeEmbedUnwrap } from 'app/lib/rehype-embed-unwrap'
@@ -32,12 +32,13 @@ function NotesListFallback() {
 
 async function NotesList() {
   const notes = await getNotes()
-  const notesResolved = await Promise.all(
-    notes.map(async (note) => ({
-      ...note,
-      mdxSource: await resolveNoteBodyWithIssueHtml(note.body, note.number),
-    }))
-  )
+  // GitHub image URLs stay in their stable user-attachments form here; the
+  // remark/rehype plugins proxy them through /api/notes-media?issue=N, which
+  // resolves short-lived private-repo URLs at request time.
+  const notesResolved = notes.map((note) => ({
+    ...note,
+    mdxSource: stripTypefullySocialHtmlCommentsForMdx(note.body || ''),
+  }))
   const missingConfig = !process.env.NOTES_GITHUB_REPO?.trim() || !process.env.GITHUB_TOKEN?.trim()
   const publishLabel = process.env.NOTES_PUBLISH_LABEL?.trim()
 
@@ -101,8 +102,8 @@ async function NotesList() {
               components={noteMdxComponents}
               options={{
                 mdxOptions: {
-                  remarkPlugins: [remarkGfm, remarkGithubNoteImages],
-                  rehypePlugins: [rehypeGithubNoteImages, rehypeSlug, rehypeEmbedUnwrap],
+                  remarkPlugins: [remarkGfm, [remarkGithubNoteImages, { issueNumber: note.number }]],
+                  rehypePlugins: [[rehypeGithubNoteImages, { issueNumber: note.number }], rehypeSlug, rehypeEmbedUnwrap],
                 },
               }}
             />


### PR DESCRIPTION
## Problem
After #78, the note image on /notes/18 was proxied but still broken: the proxied URL embedded the `private-user-images` JWT minted at render time. Those JWTs expire in ~5 minutes while the page HTML is cached for an hour, so the proxy fetched a dead URL for most of every cache window. (This flaw existed in the original markdown-image design too — the pasted-HTML image form just exposed it.)

## Fix
- Notes pages no longer swap user-attachments URLs to JWT URLs at render time. They proxy the **stable** URL with the issue number attached: `/api/notes-media?url=<user-attachments-url>&issue=N` — a stable CDN cache key, no credential in cached HTML.
- `/api/notes-media` self-heals: when the direct fetch fails (private-repo asset, expired JWT), it re-fetches the issue's rendered HTML via GraphQL (no-store), matches the asset UUID to a freshly minted URL, and serves that. Response stays CDN-cached for 24h.
- remark/rehype note-image plugins accept `{ issueNumber }`.
- `resolveNoteBodyWithIssueHtml` is now Typefully-only (uploads run right after the webhook while the JWT is fresh) and uses an uncached GraphQL fetch.
- Bonus: the notes list page no longer makes one GraphQL call per note on every render.

## Verification
- Verified via real MDX compile that both `<img>` and `![]()` forms produce `/api/notes-media?url=...&issue=N`.
- `pnpm build` green (249/249 pages), tests pass.
- After deploy, /notes/18 should re-render on first visit (new build ID invalidates the cached page) and the image should load via the self-healing proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)